### PR TITLE
refactor: create l1-deploy-multicall.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,25 +35,14 @@ verify-op-devnet:
 	@$(CURDIR)/scripts/verify-op-devnet.sh
 .PHONY: verify-op-devnet
 
-## Clean up the deployment directory
-clean-deploy-dir:
-	@rm -rf $(CURDIR)/.deploy
-.PHONY: clean-deploy-dir
-
 ## Start the OP chain
 start-op-chain: prepare-op-chain launch-op-chain
 .PHONY: start-op-chain
 
 ## Deploy the multicall contract
-deploy-multicall:
-	cd $(CURDIR)/multicall && \
-	forge build && \
-	FORGE_OUTPUT=$$(forge create --rpc-url ${L1_RPC_URL} --private-key ${L1_FUNDED_PRIVATE_KEY} Multicall3) && \
-	echo "$$FORGE_OUTPUT" && \
-	DEPLOYED_ADDRESS=$$(echo "$$FORGE_OUTPUT" | grep "Deployed to:" | awk '{print $$3}') && \
-	sed -i.bak "s/^NEXT_PUBLIC_L1_MULTICALL3_ADDRESS=.*/NEXT_PUBLIC_L1_MULTICALL3_ADDRESS=$$DEPLOYED_ADDRESS/" ../.env && \
-	rm ../.env.bak
-.PHONY: deploy-multicall
+l1-deploy-multicall:
+	@$(CURDIR)/scripts/l1-deploy-multicall.sh
+.PHONY: l1-deploy-multicall
 
 ## Launch the OP Bridge UI
 launch-op-bridge-ui:

--- a/scripts/l1-deploy-multicall.sh
+++ b/scripts/l1-deploy-multicall.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Load environment variables from the top-level .env file
+set -a
+source $(pwd)/.env
+set +a
+
+cd "$(pwd)/multicall"
+forge build
+
+# Stream forge output in real-time
+forge create --rpc-url "${L1_RPC_URL}" --private-key "${L1_FUNDED_PRIVATE_KEY}" Multicall3 | tee forge_output.log
+
+# Extract the deployed address from the log file
+DEPLOYED_ADDRESS=$(grep "Deployed to:" forge_output.log | awk '{print $3}')
+rm forge_output.log
+
+# Update the .env file with the deployed address
+sed -i.bak "s/^NEXT_PUBLIC_L1_MULTICALL3_ADDRESS=.*/NEXT_PUBLIC_L1_MULTICALL3_ADDRESS=${DEPLOYED_ADDRESS}/" ../.env
+rm ../.env.bak


### PR DESCRIPTION
## Summary

the Makefile is now a bit messy. complicated logic should be moved to its own bash scripts

also
- used `tee` to stream forge output in real-time
- removed `clean-deploy-dir` which is used not anywhere

## Test Plan

`make l1-deploy-multicall`