### PR TITLE
add check to make sure L1 chain ID is not 900 or 1337

### DIFF
--- a/scripts/l1-configure.sh
+++ b/scripts/l1-configure.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-
-
 # Generate wallet
 wallet=$(cast wallet new)
 


### PR DESCRIPTION
## Summary

see the comments in code

one decision to make is whether to put it here or in `l1-configure.sh`

I thought about it and I think it's better to put it directly in the step where l2 contracts are deployed b/c the l1 used might not be deployed using this repo

## Test Plan

set l1 chain id to 900

```
$ ./scripts/l2-deploy-l1-contracts.sh
Error: L1_CHAIN_ID cannot be 900 or 1337
```