### PR TITLE
chore: configure fund amount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ L1_CHAIN_ID=11155111
 L1_CHAIN_NAME=Sepolia
 L1_BLOCK_TIME=12
 L1_FUNDED_PRIVATE_KEY=<DEPLOYER_PRIVATE_KEY>
+# Amount to fund the ADMIN, BATCHER and PROPOSER addresses
+# Specified as a string with a unit type. e.g. 1ether, 10gwei, 0.01ether
+L1_FUND_AMOUNT=1ether
 
 # L2
 L2_CHAIN_ID=11155420

--- a/scripts/l2/l2-gen-addresses.sh
+++ b/scripts/l2/l2-gen-addresses.sh
@@ -31,7 +31,7 @@ echo "Generated new addresses and updated .env file."
 # Function to fund an address
 fund_address() {
     local address=$1
-    local amount="10ether"
+    local amount=$2
 
     cast send --private-key "$L1_FUNDED_PRIVATE_KEY" --rpc-url "$L1_RPC_URL" \
         --value "$amount" "$address"
@@ -46,8 +46,8 @@ for role in ADMIN BATCHER PROPOSER; do
     address="${!address_var}"
     
     if [[ -n "$address" ]]; then
-        echo "Funding $role address: $address"
-        fund_address "$address"
+        echo "Funding $role address: $address with amount $L1_FUND_AMOUNT"
+        fund_address "$address" "$L1_FUND_AMOUNT"
         echo
     else
         echo "Warning: $role address not found in .env file"


### PR DESCRIPTION
## Summary

This PR makes a minor change to configure the fund amount.

## Test Plan

To config the fund amount in `.env`, run the script and then check the account balance

```
L1_FUND_AMOUNT=1ether

./scripts/l2/l2-gen-addresses.sh

cast balance -e <ADMIN> --rpc-url <L1_RPC_URL>
```