### PR TITLE
fix: replace `$(pwd)` with the correct path

### DIFF
--- a/scripts/l2/l2-generate-l2-config.sh
+++ b/scripts/l2/l2-generate-l2-config.sh
@@ -56,7 +56,7 @@ echo "Authentication key created at ${JWT_SECRET_PATH}"
 echo
 
 # Move the deployment and deploy-config files to the .deploy directory
-echo "Moving the deployment and deploy-config files to the .deploy directory..."
-mv $DEPLOYMENT_OUTFILE $(pwd)/.deploy/op-devnet-deployments-${L2_CHAIN_ID}.json
-mv $DEPLOY_CONFIG_PATH $(pwd)/.deploy/op-devnet-deploy-config-${L2_CHAIN_ID}.json
+echo "Moving the deployment and deploy-config files to the ${OP_DEPLOY_DIR} directory..."
+mv $DEPLOYMENT_OUTFILE ${OP_DEPLOY_DIR}/op-devnet-deployments-${L2_CHAIN_ID}.json
+mv $DEPLOY_CONFIG_PATH ${OP_DEPLOY_DIR}/op-devnet-deploy-config-${L2_CHAIN_ID}.json
 echo


### PR DESCRIPTION
## Summary

This PR fixes an incorrect path issue, the PR https://github.com/Snapchain/op-chain-deployment/pull/32 Test Plan didn't cover this step: `make l2-prepare`. It replaces `$(pwd)` with the correct path b/c `$(pwd)` was modified by the previous code, 

## Test Plan

Tested in `tohma-devnet-2`

```
make l2-prepare
```