### PR TITLE
fix: deploy contract in non-interactive

### DIFF
--- a/scripts/l2/l2-deploy-l1-contracts.sh
+++ b/scripts/l2/l2-deploy-l1-contracts.sh
@@ -49,5 +49,5 @@ DEPLOYMENT_OUTFILE=${OP_CONTRACTS_DIR}/deployments/op-devnet-${L2_CHAIN_ID}.json
   DEPLOY_CONFIG_PATH=${OP_CONTRACTS_DIR}/deploy-config/op-devnet-${L2_CHAIN_ID}.json \
   forge script $OP_CONTRACTS_DIR/scripts/deploy/Deploy.s.sol:Deploy \
   --private-key "$GS_ADMIN_PRIVATE_KEY" \
-  --broadcast --rpc-url "$L1_RPC_URL" --slow
+  --broadcast --rpc-url "$L1_RPC_URL" --slow --non-interactive
 echo


### PR DESCRIPTION
## Summary

This PR updates script to deploy L1 contracts in non-interactive mode, b/c when launching L2 on local L1 during the `make l2-prepare` step, a warning prompt appears:

```
Warning: Script contains a transaction to 0x9568d36E291c2C4c34fa5593fcE73715abEf6F9c which does not contain any code.
Do you wish to continue? [y/n]
```

it caused the ansible script to fail with the below error:

```
TASK [Prepare for running the OP chain] ***********************************************************************************************************************************************************************************************
fatal: [165.227.85.141]: FAILED! => {"changed": true, "cmd": "make l2-prepare", "delta": "0:00:47.667666", "end": "2024-11-06 08:25:47.340154", "msg": "non-zero return code", "rc": 2, "start": "2024-11-06 08:24:59.672488", "stderr": "forge install\nWarning: Script contains a transaction to 0x9568d36E291c2C4c34fa5593fcE73715abEf6F9c which does not contain any code.\nError: IO error: not a terminal\n\nContext:\n- not a terminal\nmake: *** [Makefile:60: l2-prepare] Error 1", "stderr_lines": ["forge install", "Warning: Script contains a transaction to 0x9568d36E291c2C4c34fa5593fcE73715abEf6F9c which does not contain any code.", "Error: IO error: not a terminal", "", "Context:", "- not a terminal", "make: *** [Makefile:60: l2-prepare] Error 1"],
```

## Test Plan

Tested it on `tohma-devnet-2`

```
make l2-prepare
```