### PR TITLE
chore: remove step to set env

### DIFF
--- a/scripts/l2-bridge/l2-bridge-restart.sh
+++ b/scripts/l2-bridge/l2-bridge-restart.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Run the l2-bridge-set-env.sh script
-$(pwd)/scripts/l2-bridge/l2-bridge-set-env.sh
-
 # Source the .env file
 set -a
 source $(pwd)/.env.bridge

--- a/scripts/l2-explorer/l2-explorer-restart.sh
+++ b/scripts/l2-explorer/l2-explorer-restart.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Run the l2-blockscout-set-env.sh script
-$(pwd)/scripts/l2-explorer/l2-blockscout-set-env.sh
-
 # Source the .env.explorer file
 set -a
 source $(pwd)/.env


### PR DESCRIPTION
## Summary

This PR removes the step to set env file in restart script for bridge and explorer.

After reviewing the env file(`.env.bridge`, `.env.explorer`), setting it again for the restart case is unnecessary.

## Test Plan

Tested in `tohma-devnet-4`

```
make l2-bridge-restart
make l2-explorer-restart
```