### PR TITLE
fix: don't suppress command output in `make l2-prepare` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ l2-gen-addresses:
 
 ## Prepare for running the OP chain
 l2-prepare:
-	@$(eval export IMPL_SALT := $(shell openssl rand -hex 32))
-	@$(CURDIR)/scripts/l2/l2-generate-deploy-config.sh $(CURDIR)/optimism
-	@$(CURDIR)/scripts/l2/l2-deploy-l1-contracts.sh $(CURDIR)/optimism
-	@$(CURDIR)/scripts/l2/l2-generate-l2-config.sh $(CURDIR)/optimism $(CURDIR)/.deploy
+	$(eval export IMPL_SALT := $(shell openssl rand -hex 32))
+	$(CURDIR)/scripts/l2/l2-generate-deploy-config.sh $(CURDIR)/optimism
+	$(CURDIR)/scripts/l2/l2-deploy-l1-contracts.sh $(CURDIR)/optimism
+	$(CURDIR)/scripts/l2/l2-generate-l2-config.sh $(CURDIR)/optimism $(CURDIR)/.deploy
 .PHONY: l2-prepare
 
 ## Start the OP chain core components (op-node, op-geth, proposer, batcher)

--- a/configs/l1/network_params.yaml.example
+++ b/configs/l1/network_params.yaml.example
@@ -11,7 +11,7 @@ network_params:
 port_publisher:
   el:
     enabled: true
-    public_port_start: 18543
+    public_port_start: 18543 # JSON-RPC port 18545
   cl:
     enabled: true
-    public_port_start: 15051
+    public_port_start: 15051 # Beacon API port 15052


### PR DESCRIPTION
## Summary

https://linear.app/snapchain/issue/SNA-551/devops-use-ansiblebuiltincommand-instead-of-shell

## Test Plan

testing on a new deplolyment