### PR TITLE
chore: add restart for the docker services

### DIFF
--- a/docker/docker-compose-l2.yml
+++ b/docker/docker-compose-l2.yml
@@ -14,6 +14,7 @@ services:
       - "/entrypoint.sh"
     environment:
       GETH_MINER_RECOMMIT: 100ms
+    restart: unless-stopped
     networks:
       - ops-bedrock_default
 
@@ -45,6 +46,7 @@ services:
       - "${PWD}/.deploy/test-jwt-secret.txt:/config/jwt-secret.txt"
       - "${PWD}/.deploy/rollup.json:/rollup.json"
       - op_log:/op_log
+    restart: unless-stopped
     networks:
       - ops-bedrock_default
 
@@ -67,6 +69,7 @@ services:
       OP_PROPOSER_GAME_TYPE: "${DG_TYPE}"
       OP_PROPOSER_PROPOSAL_INTERVAL: "${PROPOSAL_INTERVAL}"
       OP_PROPOSER_RPC_ENABLE_ADMIN: "true"
+    restart: unless-stopped
     networks:
       - ops-bedrock_default
 
@@ -93,6 +96,7 @@ services:
       OP_BATCHER_TXMGR_MIN_TIP_CAP: 2.0 # 2 gwei, might need to tweak, depending on gas market
       OP_BATCHER_RESUBMISSION_TIMEOUT: 240s # wait 4 min before bumping fees
       OP_BATCHER_DATA_AVAILABILITY_TYPE: "blobs"
+    restart: unless-stopped
     networks:
       - ops-bedrock_default
 

--- a/docker/docker-compose-l2.yml
+++ b/docker/docker-compose-l2.yml
@@ -41,6 +41,8 @@ services:
       --safedb.path=/db
     ports:
       - "7545:8545"
+    environment:
+      L1_RPC_KIND: "standard"
     volumes:
       - "safedb_data:/db"
       - "${PWD}/.deploy/test-jwt-secret.txt:/config/jwt-secret.txt"


### PR DESCRIPTION
## Summary

This PR updates the docker services for L2:
* add `restart: unless-stopped` to avoid downtime
* add the env var `L1_RPC_KIND: "standard"` for the op-node to optimize block receipts fetching

more context:

Based on the OP [code](https://github.com/babylonlabs-io/optimism/blob/feat/babylon-rfc/op-service/sources/receipts_rpc.go#L349-L352), the default behavior uses the RPC method `eth_getTransactionReceipt` to fetch block receipts. 

In the case of L1 block [7142979](https://sepolia.etherscan.io/block/7142979), which includes 878 txs, this would require 878 RPC requests to fetch the block's receipts, potentially hitting RPC limits. To address this, we set the env var `L1_RPC_KIND: "standard"`, which switches to using the `eth_getBlockReceipts` method, this would only require 1 RPC request which offers better performance in terms of RPC limits.

## Test Plan

updated for devnet 7, restart works fine, and will check the op-node's log on the RPC requests for block receipts