### PR TITLE
chore: admin fund amount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .deploy
 *wallet.json
 .DS_Store
+**/.env.bak*

--- a/docker/docker-compose-l2.yml
+++ b/docker/docker-compose-l2.yml
@@ -14,6 +14,7 @@ services:
       - "/entrypoint.sh"
     environment:
       GETH_MINER_RECOMMIT: 100ms
+    restart: unless-stopped
     networks:
       - ops-bedrock_default
 
@@ -45,6 +46,7 @@ services:
       - "${PWD}/.deploy/test-jwt-secret.txt:/config/jwt-secret.txt"
       - "${PWD}/.deploy/rollup.json:/rollup.json"
       - op_log:/op_log
+    restart: unless-stopped
     networks:
       - ops-bedrock_default
 
@@ -67,6 +69,7 @@ services:
       OP_PROPOSER_GAME_TYPE: "${DG_TYPE}"
       OP_PROPOSER_PROPOSAL_INTERVAL: "${PROPOSAL_INTERVAL}"
       OP_PROPOSER_RPC_ENABLE_ADMIN: "true"
+    restart: unless-stopped
     networks:
       - ops-bedrock_default
 
@@ -93,6 +96,7 @@ services:
       OP_BATCHER_TXMGR_MIN_TIP_CAP: 2.0 # 2 gwei, might need to tweak, depending on gas market
       OP_BATCHER_RESUBMISSION_TIMEOUT: 240s # wait 4 min before bumping fees
       OP_BATCHER_DATA_AVAILABILITY_TYPE: "blobs"
+    restart: unless-stopped
     networks:
       - ops-bedrock_default
 

--- a/docker/docker-compose-l2.yml
+++ b/docker/docker-compose-l2.yml
@@ -41,6 +41,8 @@ services:
       --safedb.path=/db
     ports:
       - "7545:8545"
+    environment:
+      L1_RPC_KIND: "standard"
     volumes:
       - "safedb_data:/db"
       - "${PWD}/.deploy/test-jwt-secret.txt:/config/jwt-secret.txt"

--- a/scripts/l1/l1-verify.sh
+++ b/scripts/l1/l1-verify.sh
@@ -9,7 +9,10 @@ CL_PORT_START=$(yq '.port_publisher.cl.public_port_start' "$YAML_FILE")
 
 # Extract prefunded addresses
 PREFUNDED_ACCOUNTS=$(yq -r '.network_params.prefunded_accounts' "$YAML_FILE" | jq -r 'keys[]')
-readarray -t PREFUNDED_ACCOUNTS_ARRAY <<< "$PREFUNDED_ACCOUNTS"
+PREFUNDED_ACCOUNTS_ARRAY=()
+while IFS= read -r line; do
+    PREFUNDED_ACCOUNTS_ARRAY+=("$line")
+done <<< "$PREFUNDED_ACCOUNTS"
 
 # Calculate the actual ports
 L1_RPC_PORT=$((EL_PORT_START + 2))

--- a/scripts/l2/l2-gen-addresses.sh
+++ b/scripts/l2/l2-gen-addresses.sh
@@ -82,8 +82,14 @@ for role in ADMIN BATCHER PROPOSER; do
     if [[ -n "$address" ]]; then
         balance=$(check_address_balance "$address")
         if [[ "$balance" == "0" ]]; then
-            echo "Funding $role address: $address with amount $L1_FUND_AMOUNT"
-            fund_address "$address" "$L1_FUND_AMOUNT"
+            # fund 0.1 ETH for ADMIN, use L1_FUND_AMOUNT for BATCHER and PROPOSER
+            if [[ "$role" == "ADMIN" ]]; then
+                amount="0.1ether"
+            else
+                amount="$L1_FUND_AMOUNT"
+            fi
+            echo "Funding $role address: $address with amount $amount"
+            fund_address "$address" "$amount"
             echo
         else
             echo "Error: $role address already funded: $address"


### PR DESCRIPTION
## Summary

This PR updates to fund the admin address with 0.1ether and also:
* replaced command `readarray` with a more portable way to create an array from the prefunded accounts that works on both macOS and Linux
* `.gitignore` for `.env.bak*`, b/c running `make l2-gen-addresses` could generate the backup file env.bak-xxx if addresses already exist

## Test Plan

launch local l1:
```
make l1-configure
make l1-launch
make l1-verify
```
update the .env:
```
L1_RPC_URL=http://localhost:18545
L1_BEACON_URL=http://localhost:15052
L1_CHAIN_ID=11155222
L1_FUNDED_PRIVATE_KEY=<the key's value in the configs/l1/l1-prefund-wallet.json>
```

test it and the output:
```
make l2-gen-addresses

Generated new addresses and updated .env file.
Funding ADMIN address: 0x5B46F34d400704EbcD408282c848d8c6e523EE88 with amount 0.1ether
...
Funding BATCHER address: 0xf2125cD1Bf90EC81EC0FEFc434d8C38AB4Fa5A39 with amount 1ether
...
Funding PROPOSER address: 0x22Cc0752894A7B7F9A8dAb1E94ac5d170aE84667 with amount 1ether


Funding complete.
```

use `cast` to verify, it should also return 0.1
```
cast balance <admin address in the .env> -e --rpc-url http://localhost:18545
```
