### PR TITLE
chore: decouple `l2-bridge-set-env` from `l2-bridge-start`

### DIFF
--- a/.env.bridge.example
+++ b/.env.bridge.example
@@ -1,6 +1,7 @@
 NEXT_PUBLIC_L1_CHAIN_ID=11155111
 NEXT_PUBLIC_L1_CHAIN_NAME="Sepolia"
-NEXT_PUBLIC_L1_RPC_URL=https://sepolia.infura.io/v3/<INFURA_PROJECT_ID>
+# WARNING: This is a public RPC URL. Do not put sensitive information in it.
+NEXT_PUBLIC_L1_RPC_URL=https://rpc.ankr.com/eth_sepolia
 NEXT_PUBLIC_L1_EXPLORER_URL=https://sepolia.etherscan.io/
 NEXT_PUBLIC_L2_CHAIN_ID=11155420
 NEXT_PUBLIC_L2_CHAIN_NAME="Optimism Sepolia"

--- a/.env.bridge.example
+++ b/.env.bridge.example
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_L1_CHAIN_ID=11155111
 NEXT_PUBLIC_L1_CHAIN_NAME="Sepolia"
-# WARNING: This is a public RPC URL. Do not put sensitive information in it.
+# WARNING: The RPC URL is exposed to the browser client. We recommend using a public RPC URL.
 NEXT_PUBLIC_L1_RPC_URL=https://rpc.ankr.com/eth_sepolia
 NEXT_PUBLIC_L1_EXPLORER_URL=https://sepolia.etherscan.io/
 NEXT_PUBLIC_L2_CHAIN_ID=11155420

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,13 @@ l2-bridge-deploy-l1-multicall:
 	@$(CURDIR)/scripts/l2-bridge/l2-bridge-deploy-l1-multicall.sh
 .PHONY: l2-bridge-deploy-l1-multicall
 
+## Set the environment variables for the OP Bridge UI
+l2-bridge-set-env:
+	@$(CURDIR)/scripts/l2-bridge/l2-bridge-set-env.sh
+.PHONY: l2-bridge-set-env
+
 ## Launch the OP Bridge UI
 l2-bridge-start:
-	@$(CURDIR)/scripts/l2-bridge/l2-bridge-set-env.sh
 	@docker compose -f docker/docker-compose-l2.yml up -d op-bridge-ui
 .PHONY: l2-bridge-start
 

--- a/scripts/l2/l2-stop.sh
+++ b/scripts/l2/l2-stop.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 echo "Stopping and removing OP chain containers..."
 docker compose -f docker/docker-compose-l2.yml down
 
-# Remove the .deploy directory
-rm -rf "$(pwd)/.deploy"
+# Remove(Move) the .deploy directory
+sudo mv "$(pwd)/.deploy" "$(pwd)/.deploy-deprecated-$(date +%Y%m%d%H%M%S)"
 
 # Remove the op-chain-deployment volume
 echo "Removing the op-chain-deployment volume..."


### PR DESCRIPTION
## Summary

`make l2-bridge-start` will override the .env.bridge file with .env values for

- L1 RPC
- L2 RPC
- L2 explorer

however, this will break the bridge FE if it's on https

for example, we use our own L1 RPC for the op-node and public RPC for the bridge

this caused some confusing when I redeploy our devnet

this requires some non-trivial changes to properly fix it. for now, I just break it to two steps and update the devops playbook accordingly

## Test Plan

rerun `make l2-bridge-start` and see the bridge env not changed

https://bridge.tohma.snapchain.dev/ is now working